### PR TITLE
Fix module typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0",
   "description": "osu!stable version of osu!standard ruleset based on osu!lazer source code.",
   "exports": {
+    "types": "./lib/index.d.ts",
     "import": "./lib/index.mjs",
     "require": "./lib/index.cjs"
   },


### PR DESCRIPTION
https://arethetypeswrong.github.io/?p=osu-standard-stable%405.0.0

As can be seen in arethetypeswrong, types are not correctly pointed at because of a lack of exports.types.
osu-parsers for instance does not have this issue (https://arethetypeswrong.github.io/?p=osu-parsers%404.1.7)